### PR TITLE
register org.quodlibet.quodlibet

### DIFF
--- a/SPMediaKeyTap.m
+++ b/SPMediaKeyTap.m
@@ -153,6 +153,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 		@"com.plug.Plug",
 		@"com.plug.Plug2",
     @"com.netease.163music",
+    		@"org.quodlibet.quodlibet",
 		nil
 	];
 }


### PR DESCRIPTION
QuodLibet doesn't ship with SPMediaKeyTap yet, but better have it registered for other applications to acknowledge it.